### PR TITLE
DRYD-2 MVP Phase 3 - Network interface configuration

### DIFF
--- a/drydock_provisioner/drivers/node/maasdriver/models/base.py
+++ b/drydock_provisioner/drivers/node/maasdriver/models/base.py
@@ -29,7 +29,7 @@ class ResourceBase(object):
 
     def __init__(self, api_client, **kwargs):
         self.api_client = api_client
-        self.logger = logging.getLogger('drydock.drivers.maasdriver')
+        self.logger = logging.getLogger('drydock.nodedriver.maasdriver')
 
         for f in self.fields:
             if f in kwargs.keys():
@@ -162,7 +162,7 @@ class ResourceCollectionBase(object):
     def __init__(self, api_client):
         self.api_client = api_client
         self.resources = {}
-        self.logger = logging.getLogger('drydock.drivers.maasdriver')
+        self.logger = logging.getLogger('drydock.nodedriver.maasdriver')
 
     def interpolate_url(self):
         """

--- a/drydock_provisioner/drivers/node/maasdriver/models/interface.py
+++ b/drydock_provisioner/drivers/node/maasdriver/models/interface.py
@@ -11,18 +11,170 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 
 import drydock_provisioner.drivers.node.maasdriver.models.base as model_base
+import drydock_provisioner.drivers.node.maasdriver.models.fabric as maas_fabric
+import drydock_provisioner.drivers.node.maasdriver.models.subnet as maas_subnet
+import drydock_provisioner.drivers.node.maasdriver.models.vlan as maas_vlan
+
+import drydock_provisioner.error as errors
 
 class Interface(model_base.ResourceBase):
 
     resource_url = 'nodes/{system_id}/interfaces/{resource_id}/'
     fields = ['resource_id', 'system_id', 'name', 'type', 'mac_address', 'vlan',
-              'links', 'effective_mtu']
+              'links', 'effective_mtu', 'fabric_id']
     json_fields = ['name', 'type', 'mac_address', 'vlan', 'links', 'effective_mtu']
 
     def __init__(self, api_client, **kwargs):
         super(Interface, self).__init__(api_client, **kwargs)
+        self.logger = logging.getLogger('drydock.nodedriver.maasdriver')
+
+    def attach_fabric(self, fabric_id=None, fabric_name=None):
+        """
+        Attach this interface to a MaaS fabric. Only one of fabric_id
+        or fabric_name should be specified. If both are, fabric_id rules
+
+        :param fabric_id: The MaaS resource ID of a network Fabric to connect to
+        :param fabric_name: The name of a MaaS fabric to connect to
+        """
+
+        fabric = None
+        
+        fabrics = maas_fabric.Fabrics(self.api_client)
+        fabrics.refresh()
+
+        if fabric_id is not None:
+            fabric = fabrics.select(fabric_id)
+        elif fabric_name is not None:
+            fabric = fabrics.singleton({'name': fabric_name})
+        else:
+            self.logger.warning("Must specify fabric_id or fabric_name")
+            raise ValueError("Must specify fabric_id or fabric_name")
+
+        if fabric is None:
+            self.logger.warning("Fabric not found in MaaS for fabric_id %s, fabric_name %s" %
+                                 (fabric_id, fabric_name))
+            raise errors.DriverError("Fabric not found in MaaS for fabric_id %s, fabric_name %s" %
+                                    (fabric_id, fabric_name))
+
+        # Locate the untagged VLAN for this fabric.
+        fabric_vlan = fabric.vlans.singleton({'vid': 0})
+
+        if fabric_vlan is None:
+            self.logger.warning("Cannot locate untagged VLAN on fabric %s" % (fabric_id))
+            raise errors.DriverError("Cannot locate untagged VLAN on fabric %s" % (fabric_id))
+
+        self.vlan = fabric_vlan.resource_id
+        self.logger.info("Attaching interface %s on system %s to VLAN %s on fabric %s" %
+                         (self.resource_id, self.system_id, fabric_vlan.resource_id, fabric.resource_id))
+        self.update()
+
+    def is_linked(self, subnet_id):
+        for l in self.links:
+            if l.get('subnet_id', None) == subnet_id:
+                return True
+
+        return False
+
+    def link_subnet(self, subnet_id=None, subnet_cidr=None, ip_address=None, primary=False):
+        """
+        Link this interface to a MaaS subnet. One of subnet_id or subnet_cidr
+        should be specified. If both are, subnet_id rules.
+
+        :param subnet_id: The MaaS resource ID of a network subnet to connect to
+        :param subnet_cidr: The CIDR of a MaaS subnet to connect to
+        :param ip_address: The IP address to assign this interface. Should be a string with
+                           a static IP or None. If None, DHCP will be used.
+        :param primary: Boolean of whether this interface is the primary interface of the node. This
+                        sets the node default gateway to the gateway of the subnet
+        """
+
+        subnet = None
+
+        subnets = maas_subnet.Subnets(self.api_client)
+        subnets.refresh()
+
+        if subnet_id is not None:
+            subnet = subnets.select(subnet_id)
+        elif subnet_cidr is not None:
+            subnet = subnets.singleton({'cidr': subnet_cidr})
+        else:
+            self.logger.warning("Must specify subnet_id or subnet_cidr")
+            raise ValueError("Must specify subnet_id or subnet_cidr")
+
+        if subnet is None:
+            self.logger.warning("Subnet not found in MaaS for subnet_id %s, subnet_cidr %s" %
+                                 (subnet_id, subnet_cidr))
+            raise errors.DriverError("Subnet not found in MaaS for subnet_id %s, subnet_cidr %s" %
+                                 (subnet_id, subnet_cidr))
+
+        # TODO Possibly add logic to true up link attributes, may be overkill
+        if self.is_linked(subnet.resource_id):
+            self.logger.info("Interface %s already linked to subnet %s, skipping." %
+                            (self.resource_id, subnet.resource_id))
+            return
+
+        url = self.interpolate_url()
+
+        # TODO Probably need to enumerate link mode
+        options = { 'subnet': subnet.resource_id,
+                    'mode': 'dhcp' if ip_address is None else 'static',
+                    'default_gateway': primary,
+                  }
+
+        if ip_address is not None:
+            options['ip_address'] = ip_address
+
+        self.logger.debug("Linking interface %s to subnet: subnet=%s, mode=%s, address=%s, primary=%s" %
+                          (self.resource_id, subnet.resource_id, options['mode'], ip_address, primary))
+        
+        resp = self.api_client.post(url, op='link_subnet', files=options)
+
+        if not resp.ok:
+            self.logger.error("Error linking interface %s to subnet %s - MaaS response %s: %s" %
+                              (self.resouce_id, subnet.resource_id, resp.status_code, resp.text))
+            raise errors.DriverError("Error linking interface %s to subnet %s - MaaS response %s" %
+                              (self.resouce_id, subnet.resource_id, resp.status_code))
+
+        self.refresh()
+
+        return
+
+    @classmethod
+    def from_dict(cls, api_client, obj_dict):
+        """
+        Because MaaS decides to replace the resource ids with the
+        representation of the resource, we must reverse it for a true
+        representation of the Interface
+        """
+        refined_dict = {k: obj_dict.get(k, None) for k in cls.fields}
+        if 'id' in obj_dict.keys():
+            refined_dict['resource_id'] = obj_dict.get('id')
+
+        if isinstance(refined_dict.get('vlan', None), dict):
+            refined_dict['fabric_id'] = refined_dict['vlan']['fabric_id']
+            refined_dict['vlan'] = refined_dict['vlan']['id']
+        
+        link_list = []
+        if isinstance(refined_dict.get('links', None), list):
+            for l in refined_dict['links']:
+                if isinstance(l, dict):
+                    link = { 'resource_id': l['id'],
+                             'mode':    l['mode']
+                        }
+
+                    if l.get('subnet', None) is not None:
+                        link['subnet_id'] = l['subnet']['id']
+                        link['ip_address'] = l.get('ip_address', None)
+
+                    link_list.append(link)
+
+        refined_dict['links'] = link_list
+
+        i = cls(api_client, **refined_dict)
+        return i
 
 class Interfaces(model_base.ResourceCollectionBase):
 
@@ -32,3 +184,75 @@ class Interfaces(model_base.ResourceCollectionBase):
     def __init__(self, api_client, **kwargs):
         super(Interfaces, self).__init__(api_client)
         self.system_id = kwargs.get('system_id', None)
+
+    def create_vlan(self, vlan_tag, parent_name, mtu=None, tags=[]):
+        """
+        Create a new VLAN interface on this node
+
+        :param vlan_tag: The VLAN ID (not MaaS resource id of a VLAN) to create interface for
+        :param parent_name: The name of a MaaS interface to build the VLAN interface on top of
+        :param mtu: Optional configuration of the interface MTU
+        :param tags: Optional list of string tags to apply to the VLAN interface
+        """
+
+        self.refresh()
+
+        parent_iface = self.singleton({'name': parent_name})
+
+        if parent_iface is None:
+            self.logger.error("Cannot locate parent interface %s" % (parent_name))
+            raise errors.DriverError("Cannot locate parent interface %s" % (parent_name))
+
+        if parent_iface.type != 'physical':
+            self.logger.error("Cannot create VLAN interface on parent of type %s" % (parent_iface.type))
+            raise errors.DriverError("Cannot create VLAN interface on parent of type %s" % (parent_iface.type))
+
+        if parent_iface.vlan is None:
+            self.logger.error("Cannot create VLAN interface on disconnected parent %s" % (parent_iface.resource_id))
+            raise errors.DriverError("Cannot create VLAN interface on disconnected parent %s" % (parent_iface.resource_id))
+
+        vlans = maas_vlan.Vlans(self.api_client, fabric_id=parent_iface.fabric_id)
+        vlans.refresh()
+
+        vlan = vlans.singleton({'vid': vlan_tag})
+
+        if vlan is None:
+            self.logger.error("Cannot locate VLAN %s on fabric %s to attach interface" %
+                              (vlan_tag, parent_iface.fabric_id))
+
+        exists = self.singleton({'vlan': vlan.resource_id})
+
+        if exists is not None:
+            self.logger.info("Interface for VLAN %s already exists on node %s, skipping" %
+                             (vlan_tag, self.system_id))
+            return None
+
+        url = self.interpolate_url()
+
+        
+        options = { 'tags': ','.join(tags),
+                    'vlan': vlan.resource_id,
+                    'parent': parent_iface.resource_id,
+                  }
+
+        if mtu is not None:
+            options['mtu'] = mtu
+
+        resp = self.api_client.post(url, op='create_vlan', files=options)
+
+
+        if resp.status_code == 200:
+            resp_json = resp.json()
+            vlan_iface = Interface.from_dict(self.api_client, resp_json)
+            self.logger.debug("Created VLAN interface %s for parent %s attached to VLAN %s" %
+                              (vlan_iface.resource_id, parent_iface.resource_id, vlan.resource_id))
+            return vlan_iface
+        else:
+            self.logger.error("Error creating VLAN interface to VLAN %s on system %s - MaaS response %s: %s" %
+                              (vlan.resource_id, self.system_id, resp.status_code, resp.text))
+            raise errors.DriverError("Error creating VLAN interface to VLAN %s on system %s - MaaS response %s" %
+                              (vlan.resource_id, self.system_id, resp.status_code))
+
+        self.refresh()
+        
+        return

--- a/drydock_provisioner/drivers/node/maasdriver/models/iprange.py
+++ b/drydock_provisioner/drivers/node/maasdriver/models/iprange.py
@@ -1,0 +1,73 @@
+# Copyright 2017 AT&T Intellectual Property.  All other rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import drydock_provisioner.drivers.node.maasdriver.models.base as model_base
+
+class IpRange(model_base.ResourceBase):
+
+    resource_url = 'iprange/{resource_id}/'
+    fields = ['resource_id', 'comment', 'subnet', 'type', 'start_ip', 'end_ip']
+    json_fields = ['comment','start_ip', 'end_ip']
+
+    def __init__(self, api_client, **kwargs):
+        super(IpRange, self).__init__(api_client, **kwargs)
+
+    @classmethod
+    def from_dict(cls, api_client, obj_dict):
+        refined_dict = {k: obj_dict.get(k, None) for k in cls.fields}
+        if 'id' in obj_dict.keys():
+            refined_dict['resource_id'] = obj_dict.get('id')
+
+        if isinstance(refined_dict.get('subnet', None), dict):
+            refined_dict['subnet'] = refined_dict['subnet']['id']
+            
+        i = cls(api_client, **refined_dict)
+        return i
+
+class IpRanges(model_base.ResourceCollectionBase):
+
+    collection_url = 'ipranges/'
+    collection_resource = IpRange
+
+    def __init__(self, api_client, **kwargs):
+        super(IpRanges, self).__init__(api_client)
+
+    def add(self, res):
+        """
+        Custom add to include a subnet id and type which can't be
+        updated in a PUT
+        """
+        data_dict = res.to_dict()
+
+        subnet = getattr(res, 'subnet', None)
+
+        if subnet is not None:
+            data_dict['subnet'] = subnet
+
+        range_type = getattr(res, 'type', None)
+
+        if range_type is not None:
+            data_dict['type'] = range_type
+            
+        url = self.interpolate_url()
+
+        resp = self.api_client.post(url, files=data_dict)
+
+        if resp.status_code == 200:
+            resp_json = resp.json()
+            res.set_resource_id(resp_json.get('id'))
+            return res
+        
+        raise errors.DriverError("Failed updating MAAS url %s - return code %s"
+                % (url, resp.status_code))

--- a/drydock_provisioner/drivers/node/maasdriver/models/machine.py
+++ b/drydock_provisioner/drivers/node/maasdriver/models/machine.py
@@ -14,6 +14,7 @@
 
 import drydock_provisioner.drivers.node.maasdriver.models.base as model_base
 import drydock_provisioner.drivers.node.maasdriver.models.interface as maas_interface
+
 import bson
 import yaml
 

--- a/drydock_provisioner/drivers/node/maasdriver/models/vlan.py
+++ b/drydock_provisioner/drivers/node/maasdriver/models/vlan.py
@@ -19,8 +19,9 @@ import drydock_provisioner.drivers.node.maasdriver.models.base as model_base
 class Vlan(model_base.ResourceBase):
 
     resource_url = 'fabrics/{fabric_id}/vlans/{api_id}/'
-    fields = ['resource_id', 'name', 'description', 'vid', 'fabric_id', 'dhcp_on', 'mtu']
-    json_fields = ['name', 'description', 'vid', 'dhcp_on', 'mtu']
+    fields = ['resource_id', 'name', 'description', 'vid', 'fabric_id', 'dhcp_on', 'mtu',
+             'primary_rack', 'secondary_rack']
+    json_fields = ['name', 'description', 'vid', 'dhcp_on', 'mtu', 'primary_rack', 'secondary_rack']
 
     def __init__(self, api_client, **kwargs):
         super(Vlan, self).__init__(api_client, **kwargs)

--- a/drydock_provisioner/ingester/plugins/yaml.py
+++ b/drydock_provisioner/ingester/plugins/yaml.py
@@ -145,6 +145,8 @@ class YamlIngester(IngesterPlugin):
                         model.trunk_mode = trunking.get('mode', hd_fields.NetworkLinkTrunkingMode.Disabled)
                         model.native_network = trunking.get('default_network', None)
 
+                        model.allowed_networks = spec.get('allowed_networks', None)
+
                         models.append(model)
                     else:
                         raise ValueError('Unknown API version of object')
@@ -162,7 +164,7 @@ class YamlIngester(IngesterPlugin):
 
                             model.cidr = spec.get('cidr', None)
                             model.allocation_strategy = spec.get('allocation', 'static')
-                            model.vlan_id = spec.get('vlan_id', None)
+                            model.vlan_id = spec.get('vlan', None)
                             model.mtu = spec.get('mtu', None)
 
                             dns = spec.get('dns', {})
@@ -287,7 +289,6 @@ class YamlIngester(IngesterPlugin):
 
                             int_model.device_name = i.get('device_name', None)
                             int_model.network_link = i.get('device_link', None)
-                            int_model.primary_netowrk = i.get('primary', False)
 
                             int_model.hardware_slaves = []
                             slaves = i.get('slaves', [])
@@ -303,6 +304,8 @@ class YamlIngester(IngesterPlugin):
                             
                             model.interfaces.append(int_model)
 
+                        model.primary_network = spec.get('primary_network', None)
+                        
                         node_metadata = spec.get('metadata', {})
                         metadata_tags = node_metadata.get('tags', [])
                         model.tags = []

--- a/drydock_provisioner/objects/hostprofile.py
+++ b/drydock_provisioner/objects/hostprofile.py
@@ -51,6 +51,7 @@ class HostProfile(base.DrydockPersistentObject, base.DrydockObject):
         'base_os':  obj_fields.StringField(nullable=True),
         'kernel': obj_fields.StringField(nullable=True),
         'kernel_params': obj_fields.StringField(nullable=True),
+        'primary_network': obj_fields.StringField(nullable=False),
     }
 
     def __init__(self, **kwargs):
@@ -93,7 +94,7 @@ class HostProfile(base.DrydockPersistentObject, base.DrydockObject):
             'hardware_profile', 'oob_type', 'oob_network',
             'oob_credential', 'oob_account', 'storage_layout',
             'bootdisk_device', 'bootdisk_root_size', 'bootdisk_boot_size',
-            'rack', 'base_os', 'kernel', 'kernel_params']
+            'rack', 'base_os', 'kernel', 'kernel_params', 'primary_network']
 
         # Create applied data from self design values and parent
         # applied values
@@ -134,7 +135,6 @@ class HostInterface(base.DrydockObject):
 
     fields = {
         'device_name':  obj_fields.StringField(),
-        'primary_network': obj_fields.BooleanField(nullable=False, default=False),
         'source':   hd_fields.ModelSourceField(),
         'network_link': obj_fields.StringField(nullable=True),
         'hardware_slaves':  obj_fields.ListOfStringsField(nullable=True),
@@ -212,10 +212,6 @@ class HostInterface(base.DrydockObject):
                     elif j.get_name() == parent_name:
                         m = objects.HostInterface()
                         m.device_name = j.get_name()
-                        m.primary_network = \
-                            objects.Utils.apply_field_inheritance(
-                                getattr(j, 'primary_network', None),
-                                getattr(i, 'primary_network', None))
                             
                         m.network_link = \
                             objects.Utils.apply_field_inheritance(

--- a/drydock_provisioner/objects/network.py
+++ b/drydock_provisioner/objects/network.py
@@ -44,6 +44,7 @@ class NetworkLink(base.DrydockPersistentObject, base.DrydockObject):
         'trunk_mode':       hd_fields.NetworkLinkTrunkingModeField(
                                         default=hd_fields.NetworkLinkTrunkingMode.Disabled),
         'native_network':   ovo_fields.StringField(nullable=True),
+        'allowed_networks': ovo_fields.ListOfStringsField(),
     }
 
     def __init__(self, **kwargs):
@@ -103,8 +104,6 @@ class Network(base.DrydockPersistentObject, base.DrydockObject):
                 return r.get('gateway', None)
 
         return None
-
-
 
 @base.DrydockObjectRegistry.register
 class NetworkList(base.DrydockObjectListBase, base.DrydockObject):

--- a/drydock_provisioner/orchestrator/__init__.py
+++ b/drydock_provisioner/orchestrator/__init__.py
@@ -214,6 +214,9 @@ class Orchestrator(object):
             self.task_field_update(task_id,
                                    status=hd_fields.TaskStatus.Running)
 
+            # NOTE Should we attempt to interrogate the node via Node Driver to see if
+            # it is in a deployed state before we start rebooting? Or do we just leverage
+            # Drydock internal state via site build data (when implemented)?
             oob_driver = self.enabled_drivers['oob']
 
             if oob_driver is None:
@@ -358,6 +361,61 @@ class Orchestrator(object):
                                 result=final_result)
 
             return
+        elif task.action == hd_fields.OrchestratorAction.DeployNode:
+            failed = worked = False
+
+            self.task_field_update(task_id,
+                                   status=hd_fields.TaskStatus.Running)
+
+            node_driver = self.enabled_drivers['node']
+
+            if node_driver is None:
+                self.task_field_update(task_id,
+                        status=hd_fields.TaskStatus.Errored,
+                        result=hd_fields.ActionResult.Failure,
+                        result_detail={'detail': 'Error: No node driver configured', 'retry': False})
+                return
+
+            site_design = self.get_effective_site(design_id)
+
+            node_filter = task.node_filter
+
+            target_nodes = self.process_node_filter(node_filter, site_design)
+
+            target_names = [x.get_name() for x in target_nodes]
+
+            task_scope = {'site'        : task_site,
+                          'node_names'  : target_names}
+
+            node_networking_task = self.create_task(tasks.DriverTask,
+                                            parent_task_id=task.get_id(), design_id=design_id,
+                                            action=hd_fields.OrchestratorAction.ApplyNodeNetworking,
+                                            task_scope=task_scope)
+
+            self.logger.info("Starting node driver task %s to apply networking on nodes." % (node_networking_task.get_id()))
+            node_driver.execute_task(node_networking_task.get_id())
+
+            node_networking_task = self.state_manager.get_task(node_networking_task.get_id())
+
+            if node_networking_task.get_result() in [hd_fields.ActionResult.Success,
+                                                     hd_fields.ActionResult.PartialSuccess]:
+                worked = True
+            elif node_networking_task.get_result() in [hd_fields.ActionResult.Failure,
+                                                       hd_fields.ActionResult.PartialSuccess]:
+                failed = True
+        
+            final_result = None
+            if worked and failed:
+                final_result = hd_fields.ActionResult.PartialSuccess
+            elif worked:
+                final_result = hd_fields.ActionResult.Success
+            else:
+                final_result = hd_fields.ActionResult.Failure
+
+            self.task_field_update(task_id,
+                                status=hd_fields.TaskStatus.Complete,
+                                result=final_result)
+
         else:
             raise errors.OrchestratorError("Action %s not supported"
                                      % (task.action))

--- a/drydock_provisioner/orchestrator/readme.md
+++ b/drydock_provisioner/orchestrator/readme.md
@@ -27,7 +27,8 @@ is compatible with the physical state of the site.
 * All baremetal nodes have an address, either static or DHCP, for all networks they are attached to.
 * No static IP assignments are duplicated
 * No static IP assignments are outside of the network they are targetted for
-* No network MTU mismatches due to a network riding different links on different nodes
+* All IP assignments are within declared ranges on the network
+* Networks assigned to each node's interface are within the set of of the attached link's allowed_networks
 * Boot drive is above minimum size
 
 ### VerifySite ###

--- a/examples/designparts_v1.0.yaml
+++ b/examples/designparts_v1.0.yaml
@@ -67,6 +67,9 @@ spec:
     mode: disabled
     # If disabled, what network is this port on. If '802.1q' what is the default network for the port. No default.
     default_network: oob
+  # List of Network names that are supported on this link. A Network can be listed on only one NetworkLink
+  allowed_networks:
+  - 'oob'
 ---
 apiVersion: 'v1.0'
 kind: Network
@@ -93,7 +96,7 @@ spec:
   # Defined IP address ranges. All node IP address assignments must fall into a defined range
   # of the correct type
   ranges:
-    # Type of range. Supports 'static' or 'dhcp'. No default
+    # Type of range. Supports 'reserved', 'static' or 'dhcp'. No default
   - type: 'dhcp'
     # Start of the address range, inclusive. No default
     start: '172.16.1.100'
@@ -202,14 +205,14 @@ spec:
       fs_uuid:
       # A filesystem label. Defaults to None
       fs_label:
+    # Network name of the primary network (default gateway, DNS, etc...)
+    primary_network: 'mgmt'
     # Physical and logical network interfaces
     interfaces:
       # What the interface should be named in the operating system. May not match a hardware device name
       device_name: bond0
       # The NetworkLink connected to this interface. Must be the name of a NetworkLink design part
       device_link: 'gp'
-      # Whether this interface is considered the primary interface on the server. Supports true and false. Defaults to false
-      primary: true
       # Hardware devices that support this interface. For configurating a physical device, this would be a list of one
       # For bonds, this would be a list of all the physical devices in the bond. These can refer to HardwareProfile device aliases
       # or explicit device names


### PR DESCRIPTION
Implemented Orhcestrator task DeployNode (only network config for now)
Implemented Driver task ApplyNodeNetworking
Refactored Driver task CreateNetworkTemplate to fix design that left network
in a state that wouldn't support node configs
Updated the YAML example with some changes to support network refactoring
  - HostProfile field 'primary_network' specifies the network a node should use for default gateway
  - NetworkLinks now must list all allowed networks for that link and a Network is allowed only on a single link
Updated YAML ingester to accept schema changes